### PR TITLE
Use h5p.StandardCard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# H5P Card Blocks
+
+Create stylized cards that can include images, a title, text, and a button link.

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Displays an image, text, and a button in a bootstrap-inspired card",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 9,
+  "patchVersion": 10,
   "runnable": 1,
   "fullscreen": 0,
   "author": "@ymdahi, Yasin Dahi",

--- a/library.json
+++ b/library.json
@@ -18,12 +18,5 @@
   ],
   "preloadedCss": [
     {"path": "styles/cardblock.css"}
-  ],
-  "editorDependencies": [
-    {
-      "machineName": "H5PEditor.UrlField",
-      "majorVersion": 1,
-      "minorVersion": 2
-    }
   ]
 }

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,7 +11,7 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
-    console.log(`from cardblock: ${this.options}`);
+    console.log(`from cardblock 1: ${this.options}`);
   };
 
   /**
@@ -23,7 +23,7 @@ H5P.CardBlock = (function ($) {
 
   CardBlock.prototype.attach = function ($container) {
     $container.addClass("h5p-cardblock-container");
-    console.log(`from cardblock: ${this.options}`);
+    console.log(`from cardblock 2: ${this.options}`);
   };
 
   // /**

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -69,61 +69,6 @@ H5P.CardBlock = (function ($) {
     }
   };
 
-  // /**
-  //  * Attach function called by H5P framework to insert H5P content into
-  //  * page
-  //  *
-  //  * @param {jQuery} $container
-  //  */
-
-  // C.prototype.attach = function ($container) {
-
-  //   $container.addClass("h5p-cardblock-container");
-    
-
-  //   for (var i = 0; i < this.options.cards.length; i++) {
-
-  //     $container.append(`<div class="cardblock card-${i + 1}"></div>`);
-  //     var cardTarget = $(`.card-${i + 1}`);
-
-  //     // Add image if provided.
-  //     if (this.options.cards[i].cardImage && this.options.cards[i].cardImage.path) {
-  //       var cardMedia = `<div class="card-media"><img class="card-image" src="${H5P.getPath(this.options.cards[i].cardImage.path, this.id)}"></div>`;
-  //       cardTarget.append(cardMedia);
-  //     } else {
-  //       cardTarget.addClass('no-media');
-  //     }
-
-  //     if (this.options.cards[i].cardTitle) {
-  //       cardTarget.append(`<div class="card-body"></div>`);
-  //       var cardTitle = `<h3 class="card-title">${this.options.cards[i].cardTitle}</h3>`;
-  //       $(".card-body", cardTarget).append(cardTitle);
-  //     }
-
-  //     if (this.options.cards[i].cardText) {
-  //       var cardText = `<div class="card-text">${this.options.cards[i].cardText.params.text}</div>`;
-  //       $(".card-body", cardTarget).append(cardText);
-  //     }
-
-  //     if (this.options.cards[i].cardAction.url && this.options.cards[i].cardAction.label) {
-
-  //       var url = '';
-  //       if (this.options.cards[i].cardAction.protocol !== 'other') {
-  //         url += this.options.cards[i].cardAction.protocol;
-  //       }
-  //       url += this.options.cards[i].cardAction.url;
-
-
-  //       var cardAction = `<div class="card-action"><a class="card-action" href="${url}" target="_blank">${this.options.cards[i].cardAction.label}</a>`;
-
-  //       cardTarget.append(cardAction);
-  //     } else {
-  //       cardTarget.addClass('no-action');
-  //     }
-
-  //   }
-  // };
-
   return CardBlock;
 
 })(H5P.jQuery);

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,6 +11,7 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
+    console.log(`from cardblock 0: ${this}`);
     console.log(`from cardblock 1: ${this.options}`);
   };
 

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,9 +11,10 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
+    console.log(this.options);
   };
 
-  console.log(this);
+  
 
   /**
    * Attach function called by H5P framework to insert H5P content into

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -81,6 +81,6 @@ H5P.CardBlock = (function ($) {
   //   }
   // };
 
-  return C;
+  return CardBlock;
 
 })(H5P.jQuery);

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -4,7 +4,7 @@ H5P.CardBlock = (function ($) {
   /**
    * Constructor function.
    */
-  function C(options, id) {
+  function CardBlock(options, id) {
     // Extend defaults with provided options
     this.options = $.extend(true, {}, {
       cards: []
@@ -14,7 +14,17 @@ H5P.CardBlock = (function ($) {
     console.log(`from cardblock: ${this.options}`);
   };
 
-  
+  /**
+   * Attach function called by H5P framework to insert H5P content into
+   * page
+   *
+   * @param {jQuery} $container
+   */
+
+  CardBlock.prototype.attach = function ($container) {
+    $container.addClass("h5p-cardblock-container");
+    console.log(`from cardblock: ${this.options}`);
+  };
 
   // /**
   //  * Attach function called by H5P framework to insert H5P content into

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -48,6 +48,25 @@ H5P.CardBlock = (function ($) {
         var cardText = `<div class="card-text">${this.options.cards[i].params.cardText.params.text}</div>`;
         $(".card-body", cardTarget).append(cardText);
       }
+
+      // add card action buttons if provided
+      if (this.options.cards[i].params.cardAction.url && this.options.cards[i].params.cardAction.label) {
+
+        var url = '';
+        if (this.options.cards[i].params.cardAction.protocol !== 'other') {
+          url += this.options.cards[i].params.cardAction.protocol;
+        }
+        url += this.options.cards[i].params.cardAction.url;
+
+
+        var cardAction = `<div class="card-action"><a class="card-action" href="${url}" target="_blank">${this.options.cards[i].params.cardAction.label}</a>`;
+
+        cardTarget.append(cardAction);
+
+      } else {
+        cardTarget.addClass('no-action');
+      }
+
     }
   };
 

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,11 +11,9 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
-    console.log(`from cardblock 0: ${this}`);
-    console.log(`from cardblock 1: ${this.options}`);
+    console.log(this);
   };
 
-  console.log(`from cardblock -1: ${this}`);
   /**
    * Attach function called by H5P framework to insert H5P content into
    * page
@@ -25,7 +23,17 @@ H5P.CardBlock = (function ($) {
 
   CardBlock.prototype.attach = function ($container) {
     $container.addClass("h5p-cardblock-container");
-    console.log(`from cardblock 2: ${this.options}`);
+
+    for (var i = 0; i < this.options.cards.length; i++) {
+      $container.append(`<div class="cardblock card-${i + 1}"></div>`);
+      var cardTarget = $(`.card-${i + 1}`);
+
+      if (this.options.cards[i].cardTitle) {
+        cardTarget.append(`<div class="card-body"></div>`);
+        var cardTitle = `<h3 class="card-title">${this.options.cards[i].cardTitle}</h3>`;
+        $(".card-body", cardTarget).append(cardTitle);
+      }
+    }
   };
 
   // /**

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,17 +11,17 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
-    console.log(this.options);
+    console.log(`from cardblock: ${this.options}`);
   };
 
   
 
-  /**
-   * Attach function called by H5P framework to insert H5P content into
-   * page
-   *
-   * @param {jQuery} $container
-   */
+  // /**
+  //  * Attach function called by H5P framework to insert H5P content into
+  //  * page
+  //  *
+  //  * @param {jQuery} $container
+  //  */
 
   // C.prototype.attach = function ($container) {
 

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -15,6 +15,7 @@ H5P.CardBlock = (function ($) {
     console.log(`from cardblock 1: ${this.options}`);
   };
 
+  console.log(`from cardblock -1: ${this}`);
   /**
    * Attach function called by H5P framework to insert H5P content into
    * page

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -13,6 +13,8 @@ H5P.CardBlock = (function ($) {
     this.id = id;
   };
 
+  console.log(this);
+
   /**
    * Attach function called by H5P framework to insert H5P content into
    * page
@@ -20,92 +22,34 @@ H5P.CardBlock = (function ($) {
    * @param {jQuery} $container
    */
 
-  C.prototype.attach = function ($container) {
+  // C.prototype.attach = function ($container) {
 
-    $container.addClass("h5p-cardblock-container");
+  //   $container.addClass("h5p-cardblock-container");
     
 
-    for (var i = 0; i < this.options.cards.length; i++) {
+  //   for (var i = 0; i < this.options.cards.length; i++) {
 
-      $container.append(`<div class="cardblock card-${i + 1}"></div>`);
-      var cardTarget = $(`.card-${i + 1}`);
-
-      // Add image if provided.
-      if (this.options.cards[i].cardImage && this.options.cards[i].cardImage.path) {
-        var cardMedia = `<div class="card-media"><img class="card-image" src="${H5P.getPath(this.options.cards[i].cardImage.path, this.id)}"></div>`;
-        cardTarget.append(cardMedia);
-      } else {
-        cardTarget.addClass('no-media');
-      }
-
-      if (this.options.cards[i].cardTitle) {
-        cardTarget.append(`<div class="card-body"></div>`);
-        var cardTitle = `<h3 class="card-title">${this.options.cards[i].cardTitle}</h3>`;
-        $(".card-body", cardTarget).append(cardTitle);
-      }
-
-      if (this.options.cards[i].cardText) {
-        var cardText = `<div class="card-text">${this.options.cards[i].cardText.params.text}</div>`;
-        $(".card-body", cardTarget).append(cardText);
-      }
-
-      if (this.options.cards[i].cardAction.url && this.options.cards[i].cardAction.label) {
-
-        var url = '';
-        if (this.options.cards[i].cardAction.protocol !== 'other') {
-          url += this.options.cards[i].cardAction.protocol;
-        }
-        url += this.options.cards[i].cardAction.url;
-
-
-        var cardAction = `<div class="card-action"><a class="card-action" href="${url}" target="_blank">${this.options.cards[i].cardAction.label}</a>`;
-
-        cardTarget.append(cardAction);
-      } else {
-        cardTarget.addClass('no-action');
-      }
-
-    }
-  };
-
-  return C;
-
-})(H5P.jQuery);
-  
-  // for (var i = 0; i < this.options.cards.length; i++) {
-
-  //   /**
-  //    * Attach function called by H5P framework to insert H5P content into
-  //    * page
-  //    *
-  //    * @param {jQuery} $container
-  //    */
-  //   C.prototype.attach = function ($container) {
-  //     $container.addClass("h5p-cardblock-container");
-  //     $container.append('<div class="cardblock"></div>');
-  //     var cardTarget = $('.cardblock');
+  //     $container.append(`<div class="cardblock card-${i + 1}"></div>`);
+  //     var cardTarget = $(`.card-${i + 1}`);
 
   //     // Add image if provided.
   //     if (this.options.cards[i].cardImage && this.options.cards[i].cardImage.path) {
-  //       var cardMedia = `<div class="card-media"><img class="card-image" src="${H5P.getPath(this.options.cards[i].cardImage.path, this.id)}"></div>`
+  //       var cardMedia = `<div class="card-media"><img class="card-image" src="${H5P.getPath(this.options.cards[i].cardImage.path, this.id)}"></div>`;
   //       cardTarget.append(cardMedia);
-  //       //$cardTarget.append('<div class="card-media"><img class="card-image" src="' + H5P.getPath(this.options.cardImage.path, this.id) + '"></div>');
+  //     } else {
+  //       cardTarget.addClass('no-media');
   //     }
 
   //     if (this.options.cards[i].cardTitle) {
   //       cardTarget.append(`<div class="card-body"></div>`);
   //       var cardTitle = `<h3 class="card-title">${this.options.cards[i].cardTitle}</h3>`;
-  //       $(".card-body").append(cardTitle);
+  //       $(".card-body", cardTarget).append(cardTitle);
   //     }
 
-  //     if (this.options.cardText) {
-  //       var cardText = `<div class="card-text">${this.options.cards[i].cardText}</div>`;
-  //       $(".card-body").append(cardText);
+  //     if (this.options.cards[i].cardText) {
+  //       var cardText = `<div class="card-text">${this.options.cards[i].cardText.params.text}</div>`;
+  //       $(".card-body", cardTarget).append(cardText);
   //     }
-
-
-  //     //var sanitizedUrl = sanitizeUrlProtocol(url);
-
 
   //     if (this.options.cards[i].cardAction.url && this.options.cards[i].cardAction.label) {
 
@@ -116,13 +60,16 @@ H5P.CardBlock = (function ($) {
   //       url += this.options.cards[i].cardAction.url;
 
 
-  //       var cardAction = `<div class="card-action"><a href="card-action" href="${url}" target="_blank">${this.options.cards[i].cardAction.label}</a>`;
+  //       var cardAction = `<div class="card-action"><a class="card-action" href="${url}" target="_blank">${this.options.cards[i].cardAction.label}</a>`;
 
   //       cardTarget.append(cardAction);
+  //     } else {
+  //       cardTarget.addClass('no-action');
   //     }
 
-  //   };
-  
-//     return C;
-  
-// })(H5P.jQuery);
+  //   }
+  // };
+
+  return C;
+
+})(H5P.jQuery);

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -28,10 +28,25 @@ H5P.CardBlock = (function ($) {
       $container.append(`<div class="cardblock card-${i + 1}"></div>`);
       var cardTarget = $(`.card-${i + 1}`);
 
-      if (this.options.cards[i].cardTitle) {
+      // Add card image if provided.
+      if (this.options.cards[i].params.cardImage && this.options.cards[i].params.cardImage.path) {
+        var cardMedia = `<div class="card-media"><img class="card-image" src="${H5P.getPath(this.options.cards[i].params.cardImage.path, this.id)}"></div>`;
+        cardTarget.append(cardMedia);
+      } else {
+        cardTarget.addClass('no-media');
+      }
+
+      // add card title if provided
+      if (this.options.cards[i].params.cardTitle) {
         cardTarget.append(`<div class="card-body"></div>`);
-        var cardTitle = `<h3 class="card-title">${this.options.cards[i].cardTitle}</h3>`;
+        var cardTitle = `<h3 class="card-title">${this.options.cards[i].params.cardTitle}</h3>`;
         $(".card-body", cardTarget).append(cardTitle);
+      }
+
+      // add card text
+      if (this.options.cards[i].cardText) {
+        var cardText = `<div class="card-text">${this.options.cards[i].params.cardText.params.text}</div>`;
+        $(".card-body", cardTarget).append(cardText);
       }
     }
   };

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -44,7 +44,7 @@ H5P.CardBlock = (function ($) {
       }
 
       // add card text
-      if (this.options.cards[i].cardText) {
+      if (this.options.cards[i].params.cardText) {
         var cardText = `<div class="card-text">${this.options.cards[i].params.cardText.params.text}</div>`;
         $(".card-body", cardTarget).append(cardText);
       }

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,7 +11,6 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
-    console.log(this.options.cards);
   };
 
   /**

--- a/scripts/cardblock.js
+++ b/scripts/cardblock.js
@@ -11,7 +11,7 @@ H5P.CardBlock = (function ($) {
     }, options);
     // Keep provided id.
     this.id = id;
-    console.log(this);
+    console.log(this.options.cards);
   };
 
   /**

--- a/semantics.json
+++ b/semantics.json
@@ -18,7 +18,6 @@
           "type": "library",
           "label": "Card",
           "importance": "medium",
-          "entity": "content",
           "options": [
             "H5P.StandardCard 1.0"
           ]

--- a/semantics.json
+++ b/semantics.json
@@ -2,7 +2,7 @@
   {
     "name": "cards",
     "type": "list",
-    "label": "Panels",
+    "label": "Cards",
     "entity": "panels",
     "max": 100,
     "min": 1,

--- a/semantics.json
+++ b/semantics.json
@@ -18,6 +18,7 @@
           "type": "library",
           "label": "Card",
           "importance": "medium",
+          "entity": "content",
           "options": [
             "H5P.StandardCard 1.0"
           ]

--- a/semantics.json
+++ b/semantics.json
@@ -14,78 +14,13 @@
       "entity": "content",
       "fields": [
         {
-          "label": "Card image",
-          "name": "cardImage",
-          "type": "image",
-          "optional": true,
-          "description": "Image shown on card, optional. Without this the card will show just the text."
-        },
-        {
-          "label": "Card title", 
-          "name": "cardTitle", 
-          "type": "text", 
-          "default": "", 
-          "description": "The title of the card"
-        },
-        {
-          "name": "cardText",
+          "name": "cardElement",
           "type": "library",
-          "label": "Content type",
+          "label": "Card",
           "importance": "medium",
-          "optional": true,
           "entity": "content",
-          
           "options": [
-            "H5P.AdvancedText 1.1"
-          ]
-        },
-        {
-          "name": "cardAction",
-          "type": "group",
-          "importance": "high",
-          "optional": true,
-          "widget": "linkWidget",
-          "label": "Button",
-          "fields": [
-            {
-              "name": "protocol",
-              "type": "select",
-              "importance": "high",
-              "label": "Protocol",
-              "options": [
-                {
-                  "value": "http://",
-                  "label": "http://"
-                },
-                {
-                  "value": "https://",
-                  "label": "https://"
-                },
-                {
-                  "value": "/",
-                  "label": "(root relative)"
-                },
-                {
-                  "value": "other",
-                  "label": "other"
-                }
-              ],
-              "optional": true,
-              "default": "http://"
-            },
-            {
-              "name": "url",
-              "type": "text",
-              "importance": "high",
-              "optional": true,
-              "label": "URL"
-            },
-            {
-              "name": "label",
-              "type": "text",
-              "optional": true,
-              "label": "Button label"
-            }
+            "H5P.StandardCard 1.0"
           ]
         }
       ]


### PR DESCRIPTION
Instead of using in-place fields, we are now using the newly create h5p.standard-card library to create cards.

This allows the cards created to be clone-able and allows authors to include metadata for each card.